### PR TITLE
- feat(security): enhance security with permissions-policy and X-Powe…

### DIFF
--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -33,3 +33,13 @@ nelmio_security:
             font-src: ["'self'"]
             base-uri: ["'self'"]
             form-action: ["'self'"]
+
+    # Permissions-Policy
+    permissions_policy:
+        enabled: true
+        policies:
+            geolocation: []
+            microphone: []
+            camera: []
+            payment: []
+            usb: []

--- a/public/index.php
+++ b/public/index.php
@@ -12,6 +12,8 @@ use App\Kernel;
 
 require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
 
+header_remove('X-Powered-By');
+
 return static function (array $context) {
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 };


### PR DESCRIPTION
…red-By removal manage errors and issues from SiteOne Crawler report :

    - Powered-By header is set to 'PHP/8.4.***'. It is better not to reveal the technologies used and especially their versions.
    - Feature-Policy header is not set. It allows enabling/disabling browser APIs and features for security. Not important if Permissions-Policy is set.
    - Permissions-Policy header is not set. It allows enabling/disabling browser APIs and features for security.